### PR TITLE
filter out callback options in error meta

### DIFF
--- a/lib/invalid_model/each_serializer.rb
+++ b/lib/invalid_model/each_serializer.rb
@@ -42,7 +42,9 @@ module InvalidModel
     end
 
     def meta
-      error.options.presence
+      return unless error.options.present?
+
+      error.options.except(*ActiveModel::Error::CALLBACKS_OPTIONS)
     end
 
     def source

--- a/spec/invalid_model/each_serializer_spec.rb
+++ b/spec/invalid_model/each_serializer_spec.rb
@@ -37,6 +37,20 @@ RSpec.describe InvalidModel::EachSerializer do
     it 'shows the meta' do
       expect(hash[:meta]).to eq meta
     end
+
+    context 'when the meta object contains callback options' do
+      before do
+        meta.merge!(
+          if:        -> { 23 == 42 },
+          unless:    :admin?,
+          allow_nil: true
+        )
+      end
+
+      it 'filters out those keys' do
+        expect(hash[:meta].keys).to eq %i(foo)
+      end
+    end
   end
 
   context 'when setting custom code_format' do


### PR DESCRIPTION
Hi Konstantin,

with the latest update (version `0.2`) we started to see additional keys exposed by the serializer:

```
     Failure/Error:
       expect(response.body).to be_json_eql <<~JSON
         {
           "errors": [
             {
               "code": "validation_error/blank",
               "detail": "Os can't be blank",
               "source": {
                 "pointer": "/data/attributes/os"
               },
               "status": "400"
     
       Expected equivalent JSON
       Diff:
       @@ -3,6 +3,9 @@
            {
              "code": "validation_error/blank",
              "detail": "Os can't be blank",
       +      "meta": {
       +        "allow_nil": false
       +      },
              "source": {
                "pointer": "/data/attributes/os"
              },
```

Thought I create a quick PR to fix that.
Would be great if you could have a look whenever you have some free minutes - thank you 😁 

Best,
Klaus